### PR TITLE
apply filtered cu cost multiplier to all rows when filtering is enabled

### DIFF
--- a/src/neynar_parquet_importer/settings.py
+++ b/src/neynar_parquet_importer/settings.py
@@ -45,6 +45,7 @@ class Settings(BaseSettings):
     download_workers: int = 32
     exit_after_max_wait: bool = False  # TODO: improve this more
     file_workers: int = 4
+    filtered_row_multiplier: float = 1.1
     filter_file: Path | None = None
     incremental_duration: int = Field(300, alias="npe_duration")
     interactive_debug: bool = False


### PR DESCRIPTION
Rationale

This is being priced from a value-added perspective for the customer as
opposed to a direct-cost perspective for us. By utilizing our filtering
controls, the customer benefits from compounded savings of not having to
store and filter the data that they don't care about in their
infrastructure. This is fair because it is a one-time charge for each
row, except in cases of full imports after initial sync.

How It Works

If filtering is enable, the filtered_row_cu_cost is set equal to
row_cu_cost * filtered_row_multiplier and row_cu_cost is subsequently
zero'd out, since the filtering logic has access to the total quantity
of rows that needs to be accounted for, and the later filter-disabled
row_cu_cost accounting only has access to the rows that were not
filtered out. Note that filtered cost cu reporting is active whether or
not any rows are returned, since this is ultimately still a value-add
for the customer.
