### PR TITLE
create backfill script

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501, W503

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: backfill",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "neynar_parquet_importer.cli.backfill",
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+                "PARQUET_FILE": "nindexer-verifications-0-1749144124.parquet",
+                "START_TIMESTAMP": "1735732800",
+                "TABLES": "verifications",
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "ty.experimental.completions.enable": true
 }

--- a/schema/000_00_all_parquet_import_tracking.sql
+++ b/schema/000_00_all_parquet_import_tracking.sql
@@ -49,6 +49,18 @@ BEGIN
         RENAME TO idx_parquet_import_tracking_end_timestamp;
     END IF;
 
+    -- create backfill column
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'parquet_import_tracking'
+        AND table_schema = '${POSTGRES_SCHEMA}'
+        AND column_name = 'backfill'
+    ) THEN
+        ALTER TABLE ${POSTGRES_SCHEMA}.parquet_import_tracking
+        ADD COLUMN backfill BOOLEAN DEFAULT FALSE;
+    END IF;
+
     -- Create the index if the table is empty
     IF NOT EXISTS (SELECT 1 FROM ${POSTGRES_SCHEMA}.parquet_import_tracking LIMIT 1) THEN
         CREATE INDEX IF NOT EXISTS idx_parquet_import_tracking_table_name ON ${POSTGRES_SCHEMA}.parquet_import_tracking(table_name);

--- a/src/neynar_parquet_importer/cli/backfill.py
+++ b/src/neynar_parquet_importer/cli/backfill.py
@@ -1,31 +1,33 @@
 # TODO: take a /Users/bryan/neynar/neynar_parquet_exporter/data/v3/public-postgres/nindexer-casts-0-1744320248.parquet
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
+from datetime import datetime
 import logging
 import os
+from os import PathLike
 from pathlib import Path
+import time
 import dotenv
 from rich.progress import (
     Progress,
     MofNCompleteColumn,
+    DownloadColumn,
+    TransferSpeedColumn,
 )
 from ipdb import launch_ipdb_on_exception
 
 from neynar_parquet_importer.db import get_tables, import_parquet, init_db
 from neynar_parquet_importer.progress import ProgressCallback
-from neynar_parquet_importer.s3 import parse_parquet_filename
-from neynar_parquet_importer.s3 import download_latest_full
+from neynar_parquet_importer.s3 import parse_parquet_filename, download_known_full, get_s3_client
 from neynar_parquet_importer.settings import SHUTDOWN_EVENT, CuMode, Settings
 
 
 def main(
     settings: Settings,
-    start_timestamp: int = 0,
-    end_timestamp: int = 0,
-    parquet_file: Path | None = None,
+    parquet_file: PathLike,
+    start_timestamp: int,
+    end_timestamp: int,
 ):
-    # TODO: how can we load a single file? how should we handle the tracking table?
-
     with ExitStack() as stack:
         shutdown_executor = row_group_executor = None
         try:
@@ -50,19 +52,27 @@ def main(
                 )
             parquet_import_tracking = tables["parquet_import_tracking"]
 
-            if parsed_filename["start_timestamp"] > 0:
-                file_type = "incremental"
-            else:
-                file_type = "full"
-
             # TODO: finish the progress bars
             steps_progress = Progress(
                 *Progress.get_default_columns(),
                 MofNCompleteColumn(),
                 refresh_per_second=10,
             )
+            bytes_progress = Progress(
+                *Progress.get_default_columns(),
+                DownloadColumn(),
+                TransferSpeedColumn(),
+                refresh_per_second=10,
+            )
             progress_callback = ProgressCallback(
                 steps_progress, "files", 0, enabled=False
+            )
+            progress_callback_full_bytes = ProgressCallback(
+                bytes_progress,
+                "full_bytes",
+                0,
+                enabled=True,
+                value_type="I",
             )
             empty_callback = ProgressCallback(steps_progress, "empty", 0, enabled=False)
 
@@ -79,21 +89,30 @@ def main(
                 )
             )
 
+            download_threadpool = ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix="BackfillDownload",
+            )
+
             # TODO: move this to a helper
             f_shutdown = shutdown_executor.submit(SHUTDOWN_EVENT.wait)
 
             # TODO: load filters from an optional file
             row_filters = []
 
-            # don't use this, download a named full instead
+            s3_client = get_s3_client(settings)
+
             # future TODO: decide whether to pull latest based on start/end timestamps
-            full_filename = download_latest_full(
+            full_filename = download_known_full(
                 download_threadpool,
                 s3_client,
                 settings,
-                table,
-                progress_callbacks["full_bytes"],
+                parquet_file,
+                progress_callback_full_bytes,
             )
+
+            if end_timestamp == 0:
+                end_timestamp = parsed_filename.get("end_timestamp", int(time.time()))
 
             x = import_parquet(
                 db_engine,
@@ -107,9 +126,9 @@ def main(
                 row_filters,
                 settings,
                 f_shutdown,
-                True,  # should backfill
-                start_timestamp=start_timestamp,
-                end_timestamp=end_timestamp,
+                backfill=True,  # should backfill
+                backfill_start_timestamp=datetime.fromtimestamp(start_timestamp),
+                backfill_end_timestamp=datetime.fromtimestamp(end_timestamp),
             )
 
             logging.info("", extra={"x": x})
@@ -140,12 +159,20 @@ if __name__ == "__main__":
 
     # TODO: more pydantic?
     parquet_file = Path(os.environ["PARQUET_FILE"])
+    start_timestamp = os.environ.get("START_TIMESTAMP", None)
+    end_timestamp = int(os.environ.get("END_TIMESTAMP", 0))
+    if start_timestamp is None:
+        raise ValueError("No START_TIMESTAMP set")
+    if end_timestamp == 0:
+        logging.warning(
+            "No END_TIMESTAMP set, defaulting to 0 (now). This may not be what you want."
+        )
 
-    if not parquet_file.exists():
-        raise ValueError(f"Parquet file {parquet_file} does not exist")
+    # if not parquet_file.exists():
+    #    raise ValueError(f"Parquet file {parquet_file} does not exist")
 
     if settings.interactive_debug:
         with launch_ipdb_on_exception():
-            main(parquet_file, settings)
+            main(settings, parquet_file, start_timestamp=int(start_timestamp), end_timestamp=end_timestamp)
     else:
-        main(parquet_file, settings)
+        main(settings, parquet_file, start_timestamp=int(start_timestamp), end_timestamp=end_timestamp)

--- a/src/neynar_parquet_importer/cli/backfill.py
+++ b/src/neynar_parquet_importer/cli/backfill.py
@@ -1,0 +1,151 @@
+# TODO: take a /Users/bryan/neynar/neynar_parquet_exporter/data/v3/public-postgres/nindexer-casts-0-1744320248.parquet
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
+import logging
+import os
+from pathlib import Path
+import dotenv
+from rich.progress import (
+    Progress,
+    MofNCompleteColumn,
+)
+from ipdb import launch_ipdb_on_exception
+
+from neynar_parquet_importer.db import get_tables, import_parquet, init_db
+from neynar_parquet_importer.progress import ProgressCallback
+from neynar_parquet_importer.s3 import parse_parquet_filename
+from neynar_parquet_importer.s3 import download_latest_full
+from neynar_parquet_importer.settings import SHUTDOWN_EVENT, CuMode, Settings
+
+
+def main(
+    settings: Settings,
+    start_timestamp: int = 0,
+    end_timestamp: int = 0,
+    parquet_file: Path | None = None,
+):
+    # TODO: how can we load a single file? how should we handle the tracking table?
+
+    with ExitStack() as stack:
+        shutdown_executor = row_group_executor = None
+        try:
+            parsed_filename = parse_parquet_filename(parquet_file)
+
+            table_name = parsed_filename["table_name"]
+
+            table_names = [
+                table_name,
+            ]
+
+            db_engine = init_db(str(settings.postgres_dsn), table_names, settings)
+
+            tables = get_tables(settings.postgres_schema, db_engine, [])
+
+            try:
+                table = tables[table_name]
+            except KeyError:
+                raise KeyError(
+                    f"Table {table_name} not found in schema {settings.postgres_schema}",
+                    tables.keys(),
+                )
+            parquet_import_tracking = tables["parquet_import_tracking"]
+
+            if parsed_filename["start_timestamp"] > 0:
+                file_type = "incremental"
+            else:
+                file_type = "full"
+
+            # TODO: finish the progress bars
+            steps_progress = Progress(
+                *Progress.get_default_columns(),
+                MofNCompleteColumn(),
+                refresh_per_second=10,
+            )
+            progress_callback = ProgressCallback(
+                steps_progress, "files", 0, enabled=False
+            )
+            empty_callback = ProgressCallback(steps_progress, "empty", 0, enabled=False)
+
+            row_group_executor = stack.enter_context(
+                ThreadPoolExecutor(
+                    max_workers=settings.row_workers,
+                    thread_name_prefix=f"{table_name}Rows",
+                )
+            )
+            shutdown_executor = stack.enter_context(
+                ThreadPoolExecutor(
+                    max_workers=1,
+                    thread_name_prefix="Shutdown",
+                )
+            )
+
+            # TODO: move this to a helper
+            f_shutdown = shutdown_executor.submit(SHUTDOWN_EVENT.wait)
+
+            # TODO: load filters from an optional file
+            row_filters = []
+
+            # don't use this, download a named full instead
+            # future TODO: decide whether to pull latest based on start/end timestamps
+            full_filename = download_latest_full(
+                download_threadpool,
+                s3_client,
+                settings,
+                table,
+                progress_callbacks["full_bytes"],
+            )
+
+            x = import_parquet(
+                db_engine,
+                table,
+                full_filename,
+                'full',
+                progress_callback,
+                empty_callback,
+                parquet_import_tracking,
+                row_group_executor,
+                row_filters,
+                settings,
+                f_shutdown,
+                True,  # should backfill
+                start_timestamp=start_timestamp,
+                end_timestamp=end_timestamp,
+            )
+
+            logging.info("", extra={"x": x})
+
+            # TODO: how should we handle "mark completed?"
+        finally:
+            SHUTDOWN_EVENT.set()
+
+            if row_group_executor:
+                row_group_executor.shutdown(wait=False, cancel_futures=True)
+            else:
+                logging.error("Row group executor is None")
+
+            if shutdown_executor:
+                shutdown_executor.shutdown(wait=False, cancel_futures=True)
+            else:
+                logging.error("Shutdown executor is None")
+
+
+if __name__ == "__main__":
+    dotenv.load_dotenv(os.getenv("ENV_FILE", ".env"))
+
+    settings = Settings()
+
+    settings.cu_mode = CuMode.SHADOW
+
+    settings.initialize()
+
+    # TODO: more pydantic?
+    parquet_file = Path(os.environ["PARQUET_FILE"])
+
+    if not parquet_file.exists():
+        raise ValueError(f"Parquet file {parquet_file} does not exist")
+
+    if settings.interactive_debug:
+        with launch_ipdb_on_exception():
+            main(parquet_file, settings)
+    else:
+        main(parquet_file, settings)

--- a/src/neynar_parquet_importer/cli/backfill.py
+++ b/src/neynar_parquet_importer/cli/backfill.py
@@ -16,7 +16,7 @@ from rich.progress import (
 )
 from ipdb import launch_ipdb_on_exception
 
-from neynar_parquet_importer.db import get_tables, import_parquet, init_db
+from neynar_parquet_importer.db import get_tables, import_parquet, init_db, mark_completed
 from neynar_parquet_importer.progress import ProgressCallback
 from neynar_parquet_importer.s3 import parse_parquet_filename, download_known_full, get_s3_client
 from neynar_parquet_importer.settings import SHUTDOWN_EVENT, CuMode, Settings
@@ -131,6 +131,7 @@ def main(
                 backfill_end_timestamp=datetime.fromtimestamp(end_timestamp),
             )
 
+            mark_completed(db_engine, parquet_import_tracking, full_filename)
             logging.info("", extra={"x": x})
 
             # TODO: how should we handle "mark completed?"

--- a/src/neynar_parquet_importer/logger.py
+++ b/src/neynar_parquet_importer/logger.py
@@ -83,9 +83,9 @@ class CustomRichHandler(RichHandler):
 
 
 def setup_logging(level: str, log_format: str):
-    level = getattr(logging, level.upper(), None)
+    level_value = getattr(logging, level.upper(), None)
 
-    assert level is not None, f"Invalid log level: {level}"
+    assert level_value is not None, f"Invalid log level: {level}"
 
     if log_format == "json":
         format = "%(message)s"
@@ -104,7 +104,7 @@ def setup_logging(level: str, log_format: str):
         force=True,
         format=format,
         handlers=[logHandler],
-        level=level,
+        level=level_value,
     )
 
     logging.getLogger("asyncio").setLevel(logging.WARNING)

--- a/src/neynar_parquet_importer/main.py
+++ b/src/neynar_parquet_importer/main.py
@@ -124,6 +124,7 @@ def sync_parquet_to_db(
             parquet_import_tracking,
             settings,
             table,
+            backfill=False,
         )
 
         if existing_full_result is not None:
@@ -140,6 +141,7 @@ def sync_parquet_to_db(
             parquet_import_tracking,
             settings,
             table,
+            backfill=False,
         )
 
         if incremental_filename:
@@ -181,6 +183,7 @@ def sync_parquet_to_db(
                 parquet_import_tracking,
                 settings,
                 table,
+                backfill=False,
             )
 
             if incremental_filename:
@@ -213,6 +216,8 @@ def sync_parquet_to_db(
                         row_filters,
                         settings,
                         f_shutdown,
+                        backfill_start_timestamp=None,
+                        backfill_end_timestamp=None,
                     )
 
                     last_import_filename = incremental_filename
@@ -259,6 +264,8 @@ def sync_parquet_to_db(
                 row_filters,
                 settings,
                 f_shutdown,
+                backfill_start_timestamp=None,
+                backfill_end_timestamp=None,
             )
 
             mark_completed(db_engine, parquet_import_tracking, [full_filename])
@@ -391,7 +398,7 @@ def download_and_import_incremental_parquet(
     db_engine,
     download_threadpool: ThreadPoolExecutor,
     s3_client,
-    table: Table,
+    table,
     max_wait_duration,
     next_start_timestamp,
     progress_callbacks,
@@ -691,8 +698,9 @@ def main(settings: Settings):
                     },
                 )
 
-            if settings.filter_file:
-                with settings.filter_file.open("r") as f:
+            filter_file = settings.filter_file
+            if filter_file:
+                with filter_file.open("r") as f:
                     row_filters = orjson.loads(f.read())
             else:
                 row_filters = {}

--- a/src/neynar_parquet_importer/main.py
+++ b/src/neynar_parquet_importer/main.py
@@ -502,6 +502,8 @@ def download_and_import_incremental_parquet(
             row_filters,
             settings,
             f_shutdown,
+            backfill_start_timestamp=None,
+            backfill_end_timestamp=None,
         )
 
         # we got a file. reset max wait

--- a/src/neynar_parquet_importer/row_filters.py
+++ b/src/neynar_parquet_importer/row_filters.py
@@ -45,12 +45,18 @@ def include_by_col_data(col_data, filters: dict) -> bool:
     return True
 
 
-def include_row(row: dict, filters: dict | None) -> bool:
+def include_row(row: dict, filters: dict | None, backfill_start_timestamp: int | None = None, backfill_end_timestamp: int | None = None) -> bool:
     """
     Filters a row based on the provided filters. Rows we want will return "True"
     """
-    if filters is None:
-        return False
+    if backfill_start_timestamp is not None:
+        if row["updated_at"] < backfill_start_timestamp:
+            return False
+    if backfill_end_timestamp is not None:
+        if row["updated_at"] > backfill_end_timestamp:
+            return False
+    if filters is None or len(filters) == 0:
+        return True
 
     for key, value in filters.items():
         if key == "$and":

--- a/src/neynar_parquet_importer/s3.py
+++ b/src/neynar_parquet_importer/s3.py
@@ -2,6 +2,7 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import cache
 import math
 import os
+from os.path import basename as path_basename
 from pathlib import Path
 import re
 import shutil
@@ -16,8 +17,8 @@ from .settings import Settings
 
 
 # TODO: stricter type on this. use named groups and just return those
-def parse_parquet_filename(filename: str | Path) -> dict[str, int]:
-    basename = os.path.basename(filename)
+def parse_parquet_filename(filename: os.PathLike) -> dict[str, int]:
+    basename = path_basename(filename)
 
     match = re.match(r"(.+)-(.+)-(\d+)-(\d+)\.(?:parquet|empty)", basename)
     if match:
@@ -83,7 +84,7 @@ def download_latest_full(
 
     if os.path.exists(local_file_path):
         LOGGER.debug("%s already exists locally. Skipping download.", local_file_path)
-        return local_file_path
+        return Path(local_file_path)
 
     incoming_path = settings.incoming_dir() / full_name
 
@@ -98,7 +99,7 @@ def download_latest_full(
         download_threadpool,
     )
 
-    return local_file_path
+    return Path(local_file_path)
 
 
 def download_incremental(


### PR DESCRIPTION

A backfill process runs completely orthogonal to the main importer process.
It can be run in parallel, because it uses dedicated backfill rows in the
tracker table that are ignored by the importer.

This script accesses a file name in the env var `PARQUET_FILE`
without a path, which itself is configured as a default in settings.py.
It also accepts a backfill start and end timestamp to minimize the
processing needed and target specific holes in a user's database.

Backfills might be due to an error on our end, so it's important to
consider the choice of `CU_MODE` before running the script.

A debug config has been added for testing the backfill. Manual testing documented
in the README was utilized for regression testing.